### PR TITLE
commit https://github.com/mickael9/ioq3/commit/96f94a2891eeaa4b486de2…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1125,11 +1125,18 @@ $(echo_cmd) "REF_CC $<"
 $(Q)$(CC) $(SHLIBCFLAGS) $(CFLAGS) $(CLIENT_CFLAGS) $(OPTIMIZE) -o $@ -c $<
 endef
 
+ifeq ($(PLATFORM),mingw32)
+GLSL_SED_ARGS=-e 's/^/\"/;s/$$/\\n\"/' -e 's/\r//g'
+else
+GLSL_SED_ARGS='s/^/\"/;s/$$/\\n\"/'
+endif
+
 define DO_REF_STR
 $(echo_cmd) "REF_STR $<"
 $(Q)rm -f $@
 $(Q)echo "const char *fallbackShader_$(notdir $(basename $<)) =" >> $@
-$(Q)cat $< | sed -e 's/^/\"/;s/$$/\\n\"/' -e 's/\r//g' >> $@
+$(Q)cat $< | sed $(GLSL_SED_ARGS) >> $@
+
 $(Q)echo ";" >> $@
 endef
 


### PR DESCRIPTION
…c174ed8c00fcf0d271 broke support on OpenBSD for me.  quick fix by only using extra line endings check when platform is mingw32

can anyone confirm this still works on windows?  plus, I suppose this should also get pushed further to upstream?