### PR TITLE
Correct the problem of ping computing from the server

### DIFF
--- a/code/server/server.h
+++ b/code/server/server.h
@@ -253,6 +253,7 @@ typedef struct {
 	qboolean	initialized;				// sv_init has completed
 
 	int			time;						// will be strictly increasing across level changes
+	int			msgTime;					// will be used as precise sent time
 
 	int			snapFlagServerBit;			// ^= SNAPFLAG_SERVERCOUNT every SV_SpawnServer()
 

--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -1440,8 +1440,9 @@ static void SV_UserMove( client_t *cl, msg_t *msg, qboolean delta ) {
 		oldcmd = cmd;
 	}
 
-	// save time for ping calculation
-	cl->frames[ cl->messageAcknowledge & PACKET_MASK ].messageAcked = svs.time;
+	// save time for ping calculation, only in the first acknowledge
+	if(cl->frames[ cl->messageAcknowledge & PACKET_MASK ].messageAcked < 0)
+		cl->frames[ cl->messageAcknowledge & PACKET_MASK ].messageAcked = Sys_Milliseconds();
 
 	// TTimo
 	// catch the no-cp-yet situation before SV_ClientEnterWorld

--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -1441,7 +1441,7 @@ static void SV_UserMove( client_t *cl, msg_t *msg, qboolean delta ) {
 	}
 
 	// save time for ping calculation, only in the first acknowledge
-	if(cl->frames[ cl->messageAcknowledge & PACKET_MASK ].messageAcked < 0)
+	if ( cl->frames[ cl->messageAcknowledge & PACKET_MASK ].messageAcked == 0 )
 		cl->frames[ cl->messageAcknowledge & PACKET_MASK ].messageAcked = Sys_Milliseconds();
 
 	// TTimo

--- a/code/server/sv_main.c
+++ b/code/server/sv_main.c
@@ -939,7 +939,8 @@ Updates the cl->ping variables
 static void SV_CalcPings( void ) {
 	int			i, j;
 	client_t	*cl;
-	int			total, count;
+	int			count;
+	float		total;
 	int			delta;
 	playerState_t	*ps;
 
@@ -966,12 +967,12 @@ static void SV_CalcPings( void ) {
 			}
 			delta = cl->frames[j].messageAcked - cl->frames[j].messageSent;
 			count++;
-			total += delta;
+			total += 1.0/(delta+0.1);  // average frequency (avoiding 0 division)
 		}
 		if (!count) {
 			cl->ping = 999;
 		} else {
-			cl->ping = total/count;
+			cl->ping = (float)count/total;  // interval from average frequency
 			if ( cl->ping > 999 ) {
 				cl->ping = 999;
 			}

--- a/code/server/sv_main.c
+++ b/code/server/sv_main.c
@@ -962,7 +962,7 @@ static void SV_CalcPings( void ) {
 		total = 0;
 		count = 0;
 		for ( j = 0 ; j < PACKET_BACKUP ; j++ ) {
-			if ( cl->frames[j].messageAcked <= 0 ) {
+			if ( cl->frames[j].messageAcked == 0 ) {
 				continue;
 			}
 			delta = cl->frames[j].messageAcked - cl->frames[j].messageSent;

--- a/code/server/sv_snapshot.c
+++ b/code/server/sv_snapshot.c
@@ -598,7 +598,7 @@ void SV_SendMessageToClient(msg_t *msg, client_t *client)
 	
 	// record information about the message
 	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageSize = msg->cursize;
-	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageSent = svs.time;
+	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageSent = Sys_Milliseconds();
 	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageAcked = -1;
 
 	// send the datagram

--- a/code/server/sv_snapshot.c
+++ b/code/server/sv_snapshot.c
@@ -590,19 +590,19 @@ SV_SendMessageToClient
 Called by SV_SendClientSnapshot and SV_SendClientGameState
 =======================
 */
-void SV_SendMessageToClient(msg_t *msg, client_t *client)
+void SV_SendMessageToClient( msg_t *msg, client_t *client )
 {
-	if (client->demo_recording && !client->demo_waiting) {
-		SVD_WriteDemoFile(client, msg);
+	if ( client->demo_recording && !client->demo_waiting ) {
+		SVD_WriteDemoFile( client, msg );
 	}
 	
 	// record information about the message
 	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageSize = msg->cursize;
-	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageSent = Sys_Milliseconds();
-	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageAcked = -1;
+	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageSent = svs.msgTime;
+	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageAcked = 0;
 
 	// send the datagram
-	SV_Netchan_Transmit(client, msg);
+	SV_Netchan_Transmit( client, msg );
 }
 
 
@@ -664,6 +664,9 @@ void SV_SendClientMessages(void)
 {
 	int		i;
 	client_t	*c;
+	qboolean	lanRate;
+
+	svs.msgTime = Sys_Milliseconds();
 
 	// send a message to each connected client
 	for(i=0; i < sv_maxclients->integer; i++)
@@ -673,29 +676,26 @@ void SV_SendClientMessages(void)
 		if(!c->state)
 			continue;		// not connected
 
-		if(svs.time - c->lastSnapshotTime < c->snapshotMsec * com_timescale->value)
+		if ( svs.time - c->lastSnapshotTime < c->snapshotMsec * com_timescale->value )
 			continue;		// It's not time yet
 
-		if(c->netchan.unsentFragments || c->netchan_start_queue)
+		if ( c->netchan.unsentFragments || c->netchan_start_queue )
 		{
 			c->rateDelayed = qtrue;
 			continue;		// Drop this snapshot if the packet queue is still full or delta compression will break
 		}
+	
+		lanRate = c->netchan.remoteAddress.type == NA_LOOPBACK || (sv_lanForceRate->integer && c->netchan.isLANAddress);
 
-		if(!(c->netchan.remoteAddress.type == NA_LOOPBACK ||
-		     (sv_lanForceRate->integer && Sys_IsLANAddress(c->netchan.remoteAddress))))
+		if ( !lanRate && SV_RateMsec( c ) > 0 )
 		{
-			// rate control for clients not on LAN 
-			if(SV_RateMsec(c) > 0)
-			{
-				// Not enough time since last packet passed through the line
-				c->rateDelayed = qtrue;
-				continue;
-			}
+			// Not enough time since last packet passed through the line
+			c->rateDelayed = qtrue;
+			continue;
 		}
 
 		// generate and send a new message
-		SV_SendClientSnapshot(c);
+		SV_SendClientSnapshot( c );
 		c->lastSnapshotTime = svs.time;
 		c->rateDelayed = qfalse;
 	}


### PR DESCRIPTION
The ping, as seen from the server, is computed from acknowledge time averaged from last 32 messages. Since origins (Quake3) the differences were computed from deltas (between sent and acked) in svs.time, but that time is only increased at each snapshot in server. 
The snapshot increment time is int(1000/sv_fps), as sv_fps is currently locked at 20, the resulting increment is 50ms. Nowadays, latency bellow 50ms is very common.
Also the acknowledge time was saved every time the message and duplicates were read, resulting in wrong deltas. For clients with a real latency bellow 50 ms, there was always one packet (sent in the same snapshot) with delta=0 and 31 packets with delta=50, so the integer part of the average was always resulting 48 as ping.
The ping computed for each client is used by the server to apply a lag compensation in the position of other players sent to each client, so the wrong ping could affect the hits.
Additionally, this patch includes a change in the average of deltas to improve against sporadic sort bursts in latency. This is done by averaging frequency (inverse of delta) and then computing corresponding latency by the inverse of frequency.