### PR TITLE
Don't use host pkg-config when cross-compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,17 @@ bin_path=$(shell which $(1) 2> /dev/null)
 # set PKG_CONFIG_PATH or PKG_CONFIG to influence this, e.g.
 # PKG_CONFIG_PATH=/opt/cross/i386-mingw32msvc/lib/pkgconfig or
 # PKG_CONFIG=arm-linux-gnueabihf-pkg-config
-PKG_CONFIG ?= pkg-config
+ifeq ($(CROSS_COMPILING),0)
+  PKG_CONFIG ?= pkg-config
+else
+ifneq ($(PKG_CONFIG_PATH),)
+  PKG_CONFIG ?= pkg-config
+else
+  # Don't use host pkg-config when cross-compiling.
+  # (unknown-pkg-config is meant to be a non-existant command.)
+  PKG_CONFIG ?= unknown-pkg-config
+endif
+endif
 
 ifneq ($(call bin_path, $(PKG_CONFIG)),)
   CURL_CFLAGS ?= $(shell $(PKG_CONFIG) --silence-errors --cflags libcurl)
@@ -1264,6 +1274,7 @@ targets: makedirs
 	@echo "  COMPILE_PLATFORM: $(COMPILE_PLATFORM)"
 	@echo "  COMPILE_ARCH: $(COMPILE_ARCH)"
 	@echo "  HAVE_VM_COMPILED: $(HAVE_VM_COMPILED)"
+	@echo "  PKG_CONFIG: $(PKG_CONFIG)"
 	@echo "  CC: $(CC)"
 ifeq ($(PLATFORM),mingw32)
 	@echo "  WINDRES: $(WINDRES)"


### PR DESCRIPTION
Cross compil mingw fails because of a include in CLIENT_CFLAGS from the wrong platform

cherry-picked from: https://github.com/ioquake/ioq3/commit/302f12b8f63b7bc7c664d30eef83f563c356b407
